### PR TITLE
Vibe coding a manifest check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,9 +274,16 @@ dependencies = [
  "chrono",
  "clap",
  "kamadak-exif",
+ "md5",
  "tempfile",
  "uuid",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "mutate_once"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ kamadak-exif = "0.6.1"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 uuid = { version = "1.7", features = ["v4"] }
+md5 = "0.7"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ struct CopyConfig<'a> {
     destination: &'a Path,
     recursive: bool,
     rename: bool,
-    manifest: Option<Vec<PathBuf>>,
+    manifest: Option<Vec<String>>,
 }
 
 #[derive(Subcommand)]
@@ -83,7 +83,7 @@ fn process_path(config: &CopyConfig) -> Result<Vec<PathBuf>, Box<dyn Error>> {
     let mut copied_files = Vec::new();
 
     if config.path.is_file() {
-        copied_files.push(copy_file(config.path, config.destination, config.rename)?);
+        copied_files.push(copy_file(config.path, config.destination, config.rename, config.manifest.as_ref())?);
     } else if config.path.is_dir() && config.recursive {
         for entry in fs::read_dir(config.path)? {
             let entry = entry?;
@@ -119,7 +119,29 @@ fn generate_uuid_filename(original: &Path) -> PathBuf {
     }
 }
 
-fn copy_file(source: &Path, destination: &Path, rename: bool) -> Result<PathBuf, Box<dyn Error>> {
+fn is_duplicate(source: &Path, manifest: Option<&Vec<String>>) -> Result<Option<PathBuf>, Box<dyn Error>> {
+    let Some(manifest_paths) = manifest else { return Ok(None) };
+    
+    let mut file = File::open(source)?;
+    let mut context = md5::Context::new();
+    std::io::copy(&mut file, &mut context)?;
+    let digest = format!("{:x}", context.compute());
+
+    // Check if this MD5 exists in the manifest
+    for checksum in manifest_paths {
+        if digest == *checksum {
+            return Ok(Some(source.to_path_buf()));
+        }
+    }
+    Ok(None)
+}
+
+fn copy_file(source: &Path, destination: &Path, rename: bool, manifest: Option<&Vec<String>>) -> Result<PathBuf, Box<dyn Error>> {
+    // Check for duplicates if manifest is provided
+    if let Some(duplicate_path) = is_duplicate(source, manifest)? {
+        println!("Skipping duplicate file");
+        return Ok(duplicate_path);
+    }
     let date = get_date(source)?;
 
     // Create the date-based directory structure
@@ -149,22 +171,22 @@ fn copy_file(source: &Path, destination: &Path, rename: bool) -> Result<PathBuf,
     Ok(target_path)
 }
 
-fn parse_manifest(path: &Path) -> Result<Vec<PathBuf>, Box<dyn Error>> {
+fn parse_manifest(path: &Path) -> Result<Vec<String>, Box<dyn Error>> {
     let content = fs::read_to_string(path)?;
-    let paths: Vec<PathBuf> = content
+    let checksums: Vec<String> = content
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| {
             let parts: Vec<&str> = line.split_whitespace().collect();
-            PathBuf::from(parts[0])
+            parts[0].to_string()
         })
         .collect();
 
-    if paths.is_empty() {
+    if checksums.is_empty() {
         return Err("Manifest file is empty".into());
     }
 
-    Ok(paths)
+    Ok(checksums)
 }
 
 fn main() {
@@ -206,6 +228,42 @@ mod tests {
     use std::fs;
 
     #[test]
+    fn test_is_duplicate() -> Result<(), Box<dyn Error>> {
+        // Create a temporary directory
+        let temp_dir = TempDir::new()?;
+
+        // Create two identical files
+        let file1_path = temp_dir.path().join("file1.txt");
+        let file2_path = temp_dir.path().join("file2.txt");
+        let file3_path = temp_dir.path().join("file3.txt");
+
+        fs::write(&file1_path, b"test content")?;
+        fs::write(&file2_path, b"test content")?;  // Same content as file1
+        fs::write(&file3_path, b"different content")?;
+
+        // Test with no manifest (should return None)
+        assert!(is_duplicate(&file1_path, None)?.is_none());
+
+        // Calculate MD5 of file1
+        let mut file = File::open(&file1_path)?;
+        let mut context = md5::Context::new();
+        std::io::copy(&mut file, &mut context)?;
+        let file1_md5 = format!("{:x}", context.compute());
+
+        // Test with manifest containing no duplicates
+        let manifest = vec!["different_md5_hash".to_string()];
+        assert!(is_duplicate(&file1_path, Some(&manifest))?.is_none());
+
+        // Test with manifest containing a duplicate
+        let manifest = vec![file1_md5];
+        let result = is_duplicate(&file1_path, Some(&manifest))?;
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), file1_path);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_exif_date() {
         let path = Path::new("fixtures/exifdate.jpeg");
         let result = get_date(path).unwrap();
@@ -225,13 +283,45 @@ mod tests {
     }
 
     #[test]
+    fn test_copy_file_with_duplicates() -> Result<(), Box<dyn Error>> {
+        let temp_dir = TempDir::new()?;
+        let source = Path::new("fixtures/exifdate.jpeg");
+
+        // First, calculate the MD5 of the source file
+        let mut file = File::open(source)?;
+        let mut context = md5::Context::new();
+        std::io::copy(&mut file, &mut context)?;
+        let source_md5 = format!("{:x}", context.compute());
+
+        // Create a manifest with the source file's MD5
+        let manifest = vec![source_md5];
+
+        // Try to copy the file - it should be skipped
+        let result = copy_file(source, temp_dir.path(), false, Some(&manifest))?;
+
+        // Verify the file wasn't actually copied
+        assert!(!result.starts_with(temp_dir.path()), "File should not have been copied to temp dir");
+        assert_eq!(result, source, "Should return the source path for duplicates");
+
+        // Now try with a different MD5 in the manifest
+        let manifest = vec!["different_md5_hash".to_string()];
+        let result = copy_file(source, temp_dir.path(), false, Some(&manifest))?;
+
+        // Verify the file was copied this time
+        assert!(result.starts_with(temp_dir.path()), "File should have been copied to temp dir");
+        assert!(result.exists(), "Copied file should exist");
+
+        Ok(())
+    }
+
+    #[test]
     fn test_copy_file_with_exif() -> Result<(), Box<dyn Error>> {
         // Create a temporary directory for our test
         let temp_dir = TempDir::new()?;
 
         // Copy a file with EXIF data
         let source = Path::new("fixtures/exifdate.jpeg");
-        let result = copy_file(source, temp_dir.path(), false)?;
+        let result = copy_file(source, temp_dir.path(), false, None)?;
 
         // Verify the directory structure and file
         assert!(result.exists());
@@ -256,7 +346,7 @@ mod tests {
 
         // Copy a file without EXIF data
         let source = Path::new("fixtures/exifnodate.heif");
-        let result = copy_file(source, temp_dir.path(), false)?;
+        let result = copy_file(source, temp_dir.path(), false, None)?;
 
         // Verify the file exists and has correct name
         assert!(result.exists());
@@ -355,13 +445,10 @@ mod tests {
     #[test]
     fn test_parse_manifest() -> Result<(), Box<dyn Error>> {
         let manifest_path = Path::new("fixtures/good-bag/manifest-md5.txt");
-        let paths = parse_manifest(manifest_path)?;
+        let checksums = parse_manifest(manifest_path)?;
 
-        // Convert to a set of strings for easier comparison
-        let path_strings: HashSet<String> = paths
-            .iter()
-            .map(|p| p.to_string_lossy().into_owned())
-            .collect();
+        // Convert to a set for easier comparison
+        let checksum_set: HashSet<String> = checksums.into_iter().collect();
 
         // Expected hashes from manifest-md5.txt
         let expected_hashes: HashSet<String> = vec![
@@ -369,7 +456,7 @@ mod tests {
             "60b725f10c9c85c70d97880dfe8191b3".to_string(),
         ].into_iter().collect();
 
-        assert_eq!(path_strings, expected_hashes);
+        assert_eq!(checksum_set, expected_hashes);
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ enum Commands {
         /// Rename files using a randomly generated UUID
         #[arg(short = 'm', long)]
         rename: bool,
+        /// Path to a manifest file
+        #[arg(short = 'c', long)]
+        manifest: Option<PathBuf>,
     },
 }
 
@@ -140,7 +143,7 @@ fn main() {
                 Err(e) => println!("{}", e),
             }
         },
-        Commands::Copy { source, destination, recursive, rename } => {
+        Commands::Copy { source, destination, recursive, rename, manifest } => {
             match process_path(&source, &destination, recursive, rename) {
                 Ok(copied_files) => {
                     for path in copied_files {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ struct Config<'a> {
     destination: &'a Path,
     recursive: bool,
     rename: bool,
+    manifest: Option<Vec<PathBuf>>,
 }
 
 #[derive(Subcommand)]
@@ -92,6 +93,7 @@ fn process_path(config: &Config) -> Result<Vec<PathBuf>, Box<dyn Error>> {
                 destination: config.destination,
                 recursive: config.recursive,
                 rename: config.rename,
+                manifest: config.manifest.clone(),
             };
             copied_files.extend(process_path(&nested_config)?);
         }
@@ -176,7 +178,7 @@ fn main() {
             }
         },
         Commands::Copy { source, destination, recursive, rename, manifest } => {
-            if let Some(manifest_path) = manifest {
+            if let Some(ref manifest_path) = manifest {
                 match parse_manifest(&manifest_path) {
                     Ok(paths) => {
                         for path in paths {
@@ -185,6 +187,7 @@ fn main() {
                                 destination: &destination,
                                 recursive,
                                 rename,
+                                manifest: None,
                             };
                             match process_path(&config) {
                                 Ok(copied_files) => {
@@ -205,6 +208,7 @@ fn main() {
                 destination: &destination,
                 recursive,
                 rename,
+                manifest: manifest.as_ref().map(|m| parse_manifest(&m).unwrap_or_default()),
             };
             match process_path(&config) {
                 Ok(copied_files) => {
@@ -306,6 +310,7 @@ mod tests {
             destination: temp_dir.path(),
             recursive: false,
             rename: false,
+            manifest: None,
         };
         let results = process_path(&config)?;
 
@@ -326,6 +331,7 @@ mod tests {
             destination: temp_dir.path(),
             recursive: false,
             rename: false,
+            manifest: None,
         };
         let result = process_path(&config);
 
@@ -343,6 +349,7 @@ mod tests {
             destination: temp_dir.path(),
             recursive: true,
             rename: false,
+            manifest: None,
         };
         let results = process_path(&config)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,37 +178,12 @@ fn main() {
             }
         },
         Commands::Copy { source, destination, recursive, rename, manifest } => {
-            if let Some(ref manifest_path) = manifest {
-                match parse_manifest(&manifest_path) {
-                    Ok(paths) => {
-                        for path in paths {
-                            let config = Config {
-                                path: &path,
-                                destination: &destination,
-                                recursive,
-                                rename,
-                                manifest: None,
-                            };
-                            match process_path(&config) {
-                                Ok(copied_files) => {
-                                    for path in copied_files {
-                                        println!("Copied to {}", path.display());
-                                    }
-                                },
-                                Err(e) => println!("Error processing {}: {}", path.display(), e),
-                            }
-                        }
-                    },
-                    Err(e) => println!("Error reading manifest: {}", e),
-                }
-            }
-
             let config = Config {
                 path: &source,
                 destination: &destination,
                 recursive,
                 rename,
-                manifest: manifest.as_ref().map(|m| parse_manifest(&m).unwrap_or_default()),
+                manifest: manifest.as_ref().and_then(|m| parse_manifest(m).ok()),
             };
             match process_path(&config) {
                 Ok(copied_files) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
 }
 
 #[derive(Debug)]
-struct Config<'a> {
+struct CopyConfig<'a> {
     path: &'a Path,
     destination: &'a Path,
     recursive: bool,
@@ -79,7 +79,7 @@ fn get_date(path: &Path) -> Result<NaiveDateTime, Box<dyn Error>> {
     Ok(datetime.naive_local())
 }
 
-fn process_path(config: &Config) -> Result<Vec<PathBuf>, Box<dyn Error>> {
+fn process_path(config: &CopyConfig) -> Result<Vec<PathBuf>, Box<dyn Error>> {
     let mut copied_files = Vec::new();
 
     if config.path.is_file() {
@@ -88,7 +88,7 @@ fn process_path(config: &Config) -> Result<Vec<PathBuf>, Box<dyn Error>> {
         for entry in fs::read_dir(config.path)? {
             let entry = entry?;
             let path = entry.path();
-            let nested_config = Config {
+            let nested_config = CopyConfig {
                 path: &path,
                 destination: config.destination,
                 recursive: config.recursive,
@@ -178,7 +178,7 @@ fn main() {
             }
         },
         Commands::Copy { source, destination, recursive, rename, manifest } => {
-            let config = Config {
+            let config = CopyConfig {
                 path: &source,
                 destination: &destination,
                 recursive,
@@ -280,7 +280,7 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let source = Path::new("fixtures/exifdate.jpeg");
 
-        let config = Config {
+        let config = CopyConfig {
             path: source,
             destination: temp_dir.path(),
             recursive: false,
@@ -301,7 +301,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let source = Path::new("fixtures");
 
-        let config = Config {
+        let config = CopyConfig {
             path: source,
             destination: temp_dir.path(),
             recursive: false,
@@ -319,7 +319,7 @@ mod tests {
         let temp_dir = TempDir::new()?;
         let source = Path::new("fixtures");
 
-        let config = Config {
+        let config = CopyConfig {
             path: source,
             destination: temp_dir.path(),
             recursive: true,


### PR DESCRIPTION
Skips copying any files whose md5 checksum is present in a manifest file.