### PR TITLE
Compiling for aarch64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 test-output
+.cargo/

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This will compile the binary and install it in your Cargo binary directory (usua
 
 ## Features
 
-Builds a directory of files based on their creation date and time. Exif data is preferred, but if none is available, the file's creation time is used instead.
+Builds a directory of files based on their associated date and time. EXIF data is preferred, but if none is available, the file's modification time is used instead.
 
 ## Usage
 
 ### Date
 
-Returns the date the file was created:
+Returns the date associated with the file:
 
 ```bash
 machiver date <path_to_image>
@@ -35,3 +35,31 @@ Copies files to a new location using the date extracted from the file's metadata
 ```bash
 machiver copy <source> <destination> --recursive --rename
 ```
+
+## Cross-Compilation for Synology NAS
+
+Add the target:
+
+```bash
+rustup target add aarch64-unknown-linux-gnu
+```
+
+Install the cross-compiler tools for MacOS using brew:
+```bash
+brew tap messense/macos-cross-toolchains
+brew install aarch64-unknown-linux-gnu
+```
+
+Create `.cargo/config.toml` with:
+```toml
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+rustflags = ["-C", "target-feature=+crt-static"]
+```
+
+Build for the target:
+```bash
+cargo build --release --target aarch64-unknown-linux-gnu
+```
+
+The compiled binary will be in `target/aarch64-unknown-linux-gnu/release/machiver`.

--- a/src/date.rs
+++ b/src/date.rs
@@ -24,10 +24,10 @@ pub async fn get_date(path: &Path) -> Result<NaiveDateTime, Box<dyn Error>> {
         return Ok(date);
     }
 
-    // Fallback to file creation time
+    // Fallback to file modification time (more reliable across platforms than creation time)
     let metadata = metadata(path)?;
-    let created = metadata.created()?;
-    let datetime: DateTime<Local> = created.into();
+    let modified = metadata.modified()?;
+    let datetime: DateTime<Local> = modified.into();
     Ok(datetime.naive_local())
 }
 
@@ -47,10 +47,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_file_creation_date() {
+    async fn test_file_modified_date() {
         let path = Path::new("fixtures/exifnodate.heif");
         let result = get_date(path).await.unwrap();
-        // Since this depends on the file's creation time, we just verify
+        // Since this depends on the file's modification time, we just verify
         // that we get a valid date and don't error
         assert!(result.year() >= 2024);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,10 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Returns the date the file was created.
+    /// Returns the date associated with the file.
     ///
     /// If the file contains EXIF data, the date will be extracted from the EXIF data.
-    /// Otherwise, the file's creation time will be returned.
+    /// Otherwise, the file's modification time will be returned.
     Date {
         /// Path to the image file
         file: PathBuf,


### PR DESCRIPTION
`created` isn't available on all platforms, so use the modification date instead.